### PR TITLE
Don't wrap undefined success/error handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,15 @@ var Promise = require('es6-promise').Promise;
 module.exports = function(ns) {
   shimmer.wrap(Promise.prototype, 'then', function(then) {
     return function(onSuccess, onRejection) {
-      onSuccess = ns.bind(onSuccess);
-      onRejection = ns.bind(onRejection);
+
+      if (typeof onSuccess === 'function') {
+        onSuccess = ns.bind(onSuccess);
+      }
+
+      if (typeof onRejection === 'function') {
+        onRejection = ns.bind(onRejection);
+      }
+
       return then.call(this, onSuccess, onRejection);
     };
   });

--- a/test/functional.js
+++ b/test/functional.js
@@ -5,7 +5,7 @@ var chai = require('chai');
 var cls = require('continuation-local-storage');
 var Promise = require('es6-promise').Promise;
 var expect = chai.expect;
-
+var assert = chai.assert;
 var ns = cls.createNamespace('test');
 
 // chai config
@@ -152,6 +152,44 @@ describe('The es6-promise library', function() {
         });
 
         return Promise.all(results);
+      });
+    });
+
+    describe('when initial promise rejects in a chain', function() {
+
+      describe('and the initial handler has no onFailure handler', function() {
+
+        it('passes original error to eventual failure handler', function() {
+          var originalError = new Error('fail');
+          function shouldFail() {
+            return Promise.reject(originalError);
+          }
+
+          return shouldFail().then(function() {
+            assert.fail('should not resolve');
+          }).catch(function(err) {
+            expect(err).to.equal(originalError);
+          });
+        });
+      });
+    });
+
+    describe('when initial promise resolves in a chain', function() {
+
+      describe('and the intial handler has no onSuccess handler', function() {
+
+        it('does not generate an error', function() {
+          var originalResult = { foo: 'bar' };
+          function shouldResolve() {
+            return Promise.resolve(originalResult);
+          }
+
+          return shouldResolve().catch(function() {
+            assert.fail('should not reject');
+          }).catch(function(err) {
+            expect(err).to.not.exist();
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
When using then() without a success or error handler, or when using catch(), the shim was causing an exception to be thrown inside continuation-local-storage. This patch fixes that.

Closes #1
